### PR TITLE
chore: drop trailing / in url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Ministry of Sustainability and the Environment
-url: 'https://www.mse.gov.sg/'
+url: 'https://www.mse.gov.sg'
 favicon: /images/favicon.ico
 shareicon: /images/thumbnail.png
 # is_government: false


### PR DESCRIPTION
Typo in site url causing issues in sitemap, see https://www.mse.gov.sg/sitemap.xml.

